### PR TITLE
Fix invalid casts in Hashlink

### DIFF
--- a/src/thx/semver/VersionRule.hx
+++ b/src/thx/semver/VersionRule.hx
@@ -19,7 +19,7 @@ abstract VersionRule(VersionComparator) from VersionComparator to VersionCompara
             throw 'invalid single pattern "$comp"';
           } else {
             // one term pattern
-            var v  = versionArray(VERSION),
+            var v:Array<Int> = versionArray(VERSION),
                 vf = v.concat([0, 0, 0]).slice(0, 3);
             switch [VERSION.matched(1), v.length] {
               case ["v", 0], ["=", 0], ["", 0], [null, 0]:
@@ -145,8 +145,8 @@ abstract VersionRule(VersionComparator) from VersionComparator to VersionCompara
 
   static var IS_DIGITS = ~/^\d+$/;
   static function versionArray(re : EReg) {
-    var arr = [],
-        t;
+    var arr:Array<Int> = [];
+    var t:String;
     for(i in 2...5) {
       t = re.matched(i);
       if(null != t && IS_DIGITS.match(t))


### PR DESCRIPTION
Hashlink for some reason cannot guess the type of variable you're creating so you get this error.

![image](https://github.com/fponticelli/thx.semver/assets/88955176/e5b8e75e-f701-49b2-902c-b7b4d69bde79)
